### PR TITLE
Fix linking error

### DIFF
--- a/src/keys.h
+++ b/src/keys.h
@@ -3,81 +3,80 @@
 #include "crypto.h"
 #include "keymgr.h"
 
-struct rsa_keyset g_rsa_keyset_pkg_entry_key_3;
+extern struct rsa_keyset g_rsa_keyset_pkg_entry_key_3;
 
 #if defined(ENABLE_EKC_KEYGEN)
-struct rsa_keyset g_rsa_keyset_pkg_debug_ekpfs_key;
-struct rsa_keyset g_rsa_keyset_pkg_retail_ekpfs_key_0;
-struct rsa_keyset g_rsa_keyset_pkg_retail_ekpfs_key_1;
+extern struct rsa_keyset g_rsa_keyset_pkg_debug_ekpfs_key;
+extern struct rsa_keyset g_rsa_keyset_pkg_retail_ekpfs_key_0;
+extern struct rsa_keyset g_rsa_keyset_pkg_retail_ekpfs_key_1;
 #endif
 
-struct rsa_keyset g_rsa_keyset_pkg_fake_ekpfs_key;
+extern struct rsa_keyset g_rsa_keyset_pkg_fake_ekpfs_key;
 
-struct rsa_keyset g_rsa_keyset_pfs_sig_key;
+extern struct rsa_keyset g_rsa_keyset_pfs_sig_key;
 
-const uint8_t g_debug_pfs_zero_crypt_seed[0x10];
+extern const uint8_t g_debug_pfs_zero_crypt_seed[0x10];
 
 #if defined(ENABLE_EKC_KEYGEN)
-uint8_t* g_ekpfs_obf_key_1;
-uint8_t* g_ekpfs_obf_key_2;
-uint8_t* g_ekpfs_obf_key_3;
-uint8_t* g_ekpfs_obf_key_4;
-uint8_t* g_ekpfs_obf_key_5;
-uint8_t* g_ekpfs_obf_key_6;
-uint8_t* g_ekpfs_obf_key_7;
-uint8_t* g_ekpfs_obf_key_8;
+extern uint8_t* g_ekpfs_obf_key_1;
+extern uint8_t* g_ekpfs_obf_key_2;
+extern uint8_t* g_ekpfs_obf_key_3;
+extern uint8_t* g_ekpfs_obf_key_4;
+extern uint8_t* g_ekpfs_obf_key_5;
+extern uint8_t* g_ekpfs_obf_key_6;
+extern uint8_t* g_ekpfs_obf_key_7;
+extern uint8_t* g_ekpfs_obf_key_8;
 
-uint8_t* g_gdgp_ekc_key_0;
-uint8_t* g_gdgp_ekc_key_1;
-uint8_t* g_gdgp_ekc_key_2;
+extern uint8_t* g_gdgp_ekc_key_0;
+extern uint8_t* g_gdgp_ekc_key_1;
+extern uint8_t* g_gdgp_ekc_key_2;
 
-uint8_t* g_gdgp_content_key_obf_key;
-uint8_t* g_ac_content_key;
+extern uint8_t* g_gdgp_content_key_obf_key;
+extern uint8_t* g_ac_content_key;
 #endif
 
 #if defined(ENABLE_SD_KEYGEN)
-uint8_t* g_idps;
-uint8_t* g_open_psid;
+extern uint8_t* g_idps;
+extern uint8_t* g_open_psid;
 
-uint8_t* g_sealed_key_enc_key_1;
-uint8_t* g_sealed_key_enc_key_2;
-uint8_t* g_sealed_key_enc_key_3;
-uint8_t* g_sealed_key_enc_key_4;
-uint8_t* g_sealed_key_enc_key_5;
-uint8_t* g_sealed_key_enc_key_6;
-uint8_t* g_sealed_key_enc_key_7;
-uint8_t* g_sealed_key_enc_key_8;
-uint8_t* g_sealed_key_enc_key_9;
-uint8_t* g_sealed_key_enc_key_10;
+extern uint8_t* g_sealed_key_enc_key_1;
+extern uint8_t* g_sealed_key_enc_key_2;
+extern uint8_t* g_sealed_key_enc_key_3;
+extern uint8_t* g_sealed_key_enc_key_4;
+extern uint8_t* g_sealed_key_enc_key_5;
+extern uint8_t* g_sealed_key_enc_key_6;
+extern uint8_t* g_sealed_key_enc_key_7;
+extern uint8_t* g_sealed_key_enc_key_8;
+extern uint8_t* g_sealed_key_enc_key_9;
+extern uint8_t* g_sealed_key_enc_key_10;
 
-uint8_t* g_sealed_key_sign_key_1;
-uint8_t* g_sealed_key_sign_key_2;
-uint8_t* g_sealed_key_sign_key_3;
-uint8_t* g_sealed_key_sign_key_4;
-uint8_t* g_sealed_key_sign_key_5;
-uint8_t* g_sealed_key_sign_key_6;
-uint8_t* g_sealed_key_sign_key_7;
-uint8_t* g_sealed_key_sign_key_8;
-uint8_t* g_sealed_key_sign_key_9;
-uint8_t* g_sealed_key_sign_key_10;
+extern uint8_t* g_sealed_key_sign_key_1;
+extern uint8_t* g_sealed_key_sign_key_2;
+extern uint8_t* g_sealed_key_sign_key_3;
+extern uint8_t* g_sealed_key_sign_key_4;
+extern uint8_t* g_sealed_key_sign_key_5;
+extern uint8_t* g_sealed_key_sign_key_6;
+extern uint8_t* g_sealed_key_sign_key_7;
+extern uint8_t* g_sealed_key_sign_key_8;
+extern uint8_t* g_sealed_key_sign_key_9;
+extern uint8_t* g_sealed_key_sign_key_10;
 
-uint8_t* g_sd_auth_code_key;
+extern uint8_t* g_sd_auth_code_key;
 
-uint8_t* g_sd_hdr_data_key;
-uint8_t* g_sd_hdr_sig_key;
+extern uint8_t* g_sd_hdr_data_key;
+extern uint8_t* g_sd_hdr_sig_key;
 
-uint8_t* g_open_psid_sig_key;
+extern uint8_t* g_open_psid_sig_key;
 
-uint8_t* g_sd_content_key_1;
-uint8_t* g_sd_content_key_2;
-uint8_t* g_sd_content_key_3;
-uint8_t* g_sd_content_key_4;
-uint8_t* g_sd_content_key_5;
-uint8_t* g_sd_content_key_6;
-uint8_t* g_sd_content_key_7;
-uint8_t* g_sd_content_key_8;
-uint8_t* g_sd_content_key_9;
+extern uint8_t* g_sd_content_key_1;
+extern uint8_t* g_sd_content_key_2;
+extern uint8_t* g_sd_content_key_3;
+extern uint8_t* g_sd_content_key_4;
+extern uint8_t* g_sd_content_key_5;
+extern uint8_t* g_sd_content_key_6;
+extern uint8_t* g_sd_content_key_7;
+extern uint8_t* g_sd_content_key_8;
+extern uint8_t* g_sd_content_key_9;
 #endif
 
 int check_rsa_key_filled(const struct rsa_keyset* key, int is_private);
-


### PR DESCRIPTION
I'm trying to build this on Arch Linux and hit the following errors:

```
[ 88%] Linking C executable pkg_pfs_tool
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0x0): multiple definition of `g_rsa_keyset_pkg_entry_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0x60): multiple definition of `g_rsa_keyset_pkg_debug_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x60): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0xc0): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0xc0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0x120): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0x180): multiple definition of `g_rsa_keyset_pkg_fake_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x180): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.data.rel.local+0x1e0): multiple definition of `g_rsa_keyset_pfs_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x1e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.rodata+0x70): multiple definition of `g_debug_pfs_zero_crypt_seed'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.rodata+0x50): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x0): multiple definition of `g_ekpfs_obf_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x228): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x8): multiple definition of `g_ekpfs_obf_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x230): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x10): multiple definition of `g_ekpfs_obf_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x238): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x18): multiple definition of `g_ekpfs_obf_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x240): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x20): multiple definition of `g_ekpfs_obf_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x248): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x28): multiple definition of `g_ekpfs_obf_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x250): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x30): multiple definition of `g_ekpfs_obf_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x258): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x38): multiple definition of `g_ekpfs_obf_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x260): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x40): multiple definition of `g_gdgp_ekc_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x268): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x48): multiple definition of `g_gdgp_ekc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x270): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x50): multiple definition of `g_gdgp_ekc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x278): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x58): multiple definition of `g_gdgp_content_key_obf_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x280): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x60): multiple definition of `g_ac_content_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x288): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x68): multiple definition of `g_idps'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x290): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x70): multiple definition of `g_open_psid'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x298): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x78): multiple definition of `g_sealed_key_enc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x80): multiple definition of `g_sealed_key_enc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x88): multiple definition of `g_sealed_key_enc_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x90): multiple definition of `g_sealed_key_enc_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x98): multiple definition of `g_sealed_key_enc_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xa0): multiple definition of `g_sealed_key_enc_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xa8): multiple definition of `g_sealed_key_enc_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xb0): multiple definition of `g_sealed_key_enc_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xb8): multiple definition of `g_sealed_key_enc_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xc0): multiple definition of `g_sealed_key_enc_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xc8): multiple definition of `g_sealed_key_sign_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xd0): multiple definition of `g_sealed_key_sign_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xd8): multiple definition of `g_sealed_key_sign_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x300): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xe0): multiple definition of `g_sealed_key_sign_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x308): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xe8): multiple definition of `g_sealed_key_sign_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x310): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xf0): multiple definition of `g_sealed_key_sign_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x318): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0xf8): multiple definition of `g_sealed_key_sign_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x320): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x100): multiple definition of `g_sealed_key_sign_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x328): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x108): multiple definition of `g_sealed_key_sign_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x330): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x110): multiple definition of `g_sealed_key_sign_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x338): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x118): multiple definition of `g_sd_auth_code_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x340): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x120): multiple definition of `g_sd_hdr_data_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x348): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x128): multiple definition of `g_sd_hdr_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x350): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x130): multiple definition of `g_open_psid_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x358): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x138): multiple definition of `g_sd_content_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x360): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x140): multiple definition of `g_sd_content_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x368): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x148): multiple definition of `g_sd_content_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x370): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x150): multiple definition of `g_sd_content_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x378): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x158): multiple definition of `g_sd_content_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x380): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x160): multiple definition of `g_sd_content_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x388): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x168): multiple definition of `g_sd_content_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x390): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x170): multiple definition of `g_sd_content_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x398): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/keys.c.o:(.bss+0x178): multiple definition of `g_sd_content_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x3a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x0): multiple definition of `g_rsa_keyset_pkg_entry_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x60): multiple definition of `g_rsa_keyset_pkg_debug_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x60): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0xc0): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0xc0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x120): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x180): multiple definition of `g_rsa_keyset_pkg_fake_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x180): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x1e0): multiple definition of `g_rsa_keyset_pfs_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x1e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.rodata+0x0): multiple definition of `g_debug_pfs_zero_crypt_seed'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.rodata+0x50): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x228): multiple definition of `g_ekpfs_obf_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x228): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x230): multiple definition of `g_ekpfs_obf_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x230): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x238): multiple definition of `g_ekpfs_obf_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x238): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x240): multiple definition of `g_ekpfs_obf_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x240): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x248): multiple definition of `g_ekpfs_obf_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x248): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x250): multiple definition of `g_ekpfs_obf_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x250): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x258): multiple definition of `g_ekpfs_obf_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x258): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x260): multiple definition of `g_ekpfs_obf_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x260): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x268): multiple definition of `g_gdgp_ekc_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x268): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x270): multiple definition of `g_gdgp_ekc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x270): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x278): multiple definition of `g_gdgp_ekc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x278): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x280): multiple definition of `g_gdgp_content_key_obf_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x280): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x288): multiple definition of `g_ac_content_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x288): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x290): multiple definition of `g_idps'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x290): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x298): multiple definition of `g_open_psid'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x298): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2a0): multiple definition of `g_sealed_key_enc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2a8): multiple definition of `g_sealed_key_enc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2b0): multiple definition of `g_sealed_key_enc_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2b8): multiple definition of `g_sealed_key_enc_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2c0): multiple definition of `g_sealed_key_enc_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2c8): multiple definition of `g_sealed_key_enc_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2d0): multiple definition of `g_sealed_key_enc_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2d8): multiple definition of `g_sealed_key_enc_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2e0): multiple definition of `g_sealed_key_enc_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2e8): multiple definition of `g_sealed_key_enc_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2f0): multiple definition of `g_sealed_key_sign_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x2f8): multiple definition of `g_sealed_key_sign_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x300): multiple definition of `g_sealed_key_sign_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x300): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x308): multiple definition of `g_sealed_key_sign_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x308): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x310): multiple definition of `g_sealed_key_sign_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x310): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x318): multiple definition of `g_sealed_key_sign_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x318): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x320): multiple definition of `g_sealed_key_sign_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x320): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x328): multiple definition of `g_sealed_key_sign_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x328): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x330): multiple definition of `g_sealed_key_sign_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x330): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x338): multiple definition of `g_sealed_key_sign_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x338): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x340): multiple definition of `g_sd_auth_code_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x340): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x348): multiple definition of `g_sd_hdr_data_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x348): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x350): multiple definition of `g_sd_hdr_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x350): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x358): multiple definition of `g_open_psid_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x358): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x360): multiple definition of `g_sd_content_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x360): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x368): multiple definition of `g_sd_content_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x368): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x370): multiple definition of `g_sd_content_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x370): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x378): multiple definition of `g_sd_content_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x378): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x380): multiple definition of `g_sd_content_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x380): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x388): multiple definition of `g_sd_content_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x388): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x390): multiple definition of `g_sd_content_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x390): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x398): multiple definition of `g_sd_content_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x398): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs.c.o:(.bss+0x3a0): multiple definition of `g_sd_content_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x3a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x0): multiple definition of `g_rsa_keyset_pkg_entry_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x60): multiple definition of `g_rsa_keyset_pkg_debug_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x60): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0xc0): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0xc0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x120): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x180): multiple definition of `g_rsa_keyset_pkg_fake_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x180): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x1e0): multiple definition of `g_rsa_keyset_pfs_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x1e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.rodata+0x0): multiple definition of `g_debug_pfs_zero_crypt_seed'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.rodata+0x50): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x228): multiple definition of `g_ekpfs_obf_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x228): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x230): multiple definition of `g_ekpfs_obf_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x230): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x238): multiple definition of `g_ekpfs_obf_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x238): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x240): multiple definition of `g_ekpfs_obf_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x240): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x248): multiple definition of `g_ekpfs_obf_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x248): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x250): multiple definition of `g_ekpfs_obf_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x250): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x258): multiple definition of `g_ekpfs_obf_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x258): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x260): multiple definition of `g_ekpfs_obf_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x260): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x268): multiple definition of `g_gdgp_ekc_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x268): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x270): multiple definition of `g_gdgp_ekc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x270): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x278): multiple definition of `g_gdgp_ekc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x278): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x280): multiple definition of `g_gdgp_content_key_obf_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x280): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x288): multiple definition of `g_ac_content_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x288): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x290): multiple definition of `g_idps'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x290): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x298): multiple definition of `g_open_psid'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x298): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2a0): multiple definition of `g_sealed_key_enc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2a8): multiple definition of `g_sealed_key_enc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2b0): multiple definition of `g_sealed_key_enc_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2b8): multiple definition of `g_sealed_key_enc_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2c0): multiple definition of `g_sealed_key_enc_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2c8): multiple definition of `g_sealed_key_enc_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2d0): multiple definition of `g_sealed_key_enc_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2d8): multiple definition of `g_sealed_key_enc_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2e0): multiple definition of `g_sealed_key_enc_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2e8): multiple definition of `g_sealed_key_enc_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2f0): multiple definition of `g_sealed_key_sign_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x2f8): multiple definition of `g_sealed_key_sign_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x300): multiple definition of `g_sealed_key_sign_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x300): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x308): multiple definition of `g_sealed_key_sign_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x308): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x310): multiple definition of `g_sealed_key_sign_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x310): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x318): multiple definition of `g_sealed_key_sign_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x318): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x320): multiple definition of `g_sealed_key_sign_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x320): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x328): multiple definition of `g_sealed_key_sign_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x328): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x330): multiple definition of `g_sealed_key_sign_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x330): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x338): multiple definition of `g_sealed_key_sign_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x338): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x340): multiple definition of `g_sd_auth_code_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x340): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x348): multiple definition of `g_sd_hdr_data_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x348): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x350): multiple definition of `g_sd_hdr_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x350): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x358): multiple definition of `g_open_psid_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x358): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x360): multiple definition of `g_sd_content_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x360): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x368): multiple definition of `g_sd_content_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x368): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x370): multiple definition of `g_sd_content_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x370): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x378): multiple definition of `g_sd_content_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x378): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x380): multiple definition of `g_sd_content_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x380): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x388): multiple definition of `g_sd_content_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x388): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x390): multiple definition of `g_sd_content_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x390): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x398): multiple definition of `g_sd_content_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x398): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pfs_sd.c.o:(.bss+0x3a0): multiple definition of `g_sd_content_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x3a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x0): multiple definition of `g_rsa_keyset_pkg_entry_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x60): multiple definition of `g_rsa_keyset_pkg_debug_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x60): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0xc0): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0xc0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x120): multiple definition of `g_rsa_keyset_pkg_retail_ekpfs_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x180): multiple definition of `g_rsa_keyset_pkg_fake_ekpfs_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x180): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x1e0): multiple definition of `g_rsa_keyset_pfs_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x1e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.rodata+0xa0): multiple definition of `g_debug_pfs_zero_crypt_seed'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.rodata+0x50): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x228): multiple definition of `g_ekpfs_obf_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x228): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x230): multiple definition of `g_ekpfs_obf_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x230): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x238): multiple definition of `g_ekpfs_obf_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x238): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x240): multiple definition of `g_ekpfs_obf_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x240): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x248): multiple definition of `g_ekpfs_obf_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x248): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x250): multiple definition of `g_ekpfs_obf_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x250): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x258): multiple definition of `g_ekpfs_obf_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x258): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x260): multiple definition of `g_ekpfs_obf_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x260): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x268): multiple definition of `g_gdgp_ekc_key_0'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x268): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x270): multiple definition of `g_gdgp_ekc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x270): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x278): multiple definition of `g_gdgp_ekc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x278): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x280): multiple definition of `g_gdgp_content_key_obf_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x280): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x288): multiple definition of `g_ac_content_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x288): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x290): multiple definition of `g_idps'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x290): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x298): multiple definition of `g_open_psid'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x298): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2a0): multiple definition of `g_sealed_key_enc_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2a8): multiple definition of `g_sealed_key_enc_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2a8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2b0): multiple definition of `g_sealed_key_enc_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2b8): multiple definition of `g_sealed_key_enc_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2b8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2c0): multiple definition of `g_sealed_key_enc_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2c8): multiple definition of `g_sealed_key_enc_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2c8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2d0): multiple definition of `g_sealed_key_enc_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2d8): multiple definition of `g_sealed_key_enc_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2d8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2e0): multiple definition of `g_sealed_key_enc_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2e8): multiple definition of `g_sealed_key_enc_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2e8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2f0): multiple definition of `g_sealed_key_sign_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f0): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x2f8): multiple definition of `g_sealed_key_sign_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x2f8): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x300): multiple definition of `g_sealed_key_sign_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x300): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x308): multiple definition of `g_sealed_key_sign_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x308): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x310): multiple definition of `g_sealed_key_sign_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x310): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x318): multiple definition of `g_sealed_key_sign_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x318): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x320): multiple definition of `g_sealed_key_sign_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x320): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x328): multiple definition of `g_sealed_key_sign_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x328): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x330): multiple definition of `g_sealed_key_sign_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x330): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x338): multiple definition of `g_sealed_key_sign_key_10'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x338): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x340): multiple definition of `g_sd_auth_code_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x340): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x348): multiple definition of `g_sd_hdr_data_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x348): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x350): multiple definition of `g_sd_hdr_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x350): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x358): multiple definition of `g_open_psid_sig_key'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x358): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x360): multiple definition of `g_sd_content_key_1'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x360): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x368): multiple definition of `g_sd_content_key_2'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x368): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x370): multiple definition of `g_sd_content_key_3'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x370): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x378): multiple definition of `g_sd_content_key_4'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x378): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x380): multiple definition of `g_sd_content_key_5'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x380): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x388): multiple definition of `g_sd_content_key_6'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x388): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x390): multiple definition of `g_sd_content_key_7'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x390): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x398): multiple definition of `g_sd_content_key_8'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x398): first defined here
/usr/bin/ld: CMakeFiles/pkg_pfs_tool.dir/src/pkg.c.o:(.bss+0x3a0): multiple definition of `g_sd_content_key_9'; CMakeFiles/pkg_pfs_tool.dir/src/keymgr.c.o:(.bss+0x3a0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/pkg_pfs_tool.dir/build.make:469: pkg_pfs_tool] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/pkg_pfs_tool.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

This PR is a fix for this problem.