### PR TITLE
Fix cmake include dirs variable when using thirdparty libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,11 @@ include_directories(${ZLIB_INCLUDE_DIRS})
 list(APPEND LIBS ${ZLIB_LIBRARIES})
 
 find_package(MBEDTLS 2.24.0 REQUIRED)
-include_directories(${MBEDTLS_INCLUDE_DIRS})
+include_directories(${MBEDTLS_INCLUDE_DIR})
 list(APPEND LIBS ${MBEDTLS_LIBRARIES})
 
 find_package(UTHASH REQUIRED)
-include_directories(${UTHASH_INCLUDE_DIRS})
+include_directories(${UTHASH_INCLUDE_DIR})
 
 #
 # Project settings.


### PR DESCRIPTION
This allows the build to work when using the include headers / libs from thirdparty folder. Just a minor mistake in the variable name that comes from the Find*.cmake files